### PR TITLE
Bump commons-io in /07-Microservices-Deployment/notifications-service

### DIFF
--- a/07-Microservices-Deployment/notifications-service/pom.xml
+++ b/07-Microservices-Deployment/notifications-service/pom.xml
@@ -43,7 +43,7 @@
 				<dependency>
 					<groupId>commons-io</groupId>
 					<artifactId>commons-io</artifactId>
-					<version>2.5</version>
+					<version>2.7</version>
 				</dependency>
 
 				<dependency>


### PR DESCRIPTION
Bumps commons-io from 2.5 to 2.7.